### PR TITLE
Add iOSUser customer custom type

### DIFF
--- a/joyride/types.json
+++ b/joyride/types.json
@@ -82,5 +82,42 @@
         "inputHint": "SingleLine"
       }
     ]
+  },
+  {
+    "key": "iOSUser",
+    "name": {
+      "de": "iOSUser",
+      "en": "iOSUser"
+    },
+    "resourceTypeIds": [
+      "customer"
+    ],
+    "fieldDefinitions": [
+      {
+        "name": "apnsToken",
+        "label": {
+          "en": "apnsToken",
+          "de": "apnsToken"
+        },
+        "required": false,
+        "type": {
+          "name": "String"
+        },
+        "inputHint": "SingleLine"
+      },
+      {
+        "name": "myStore",
+        "label": {
+          "en": "myStore",
+          "de": "meinLaden"
+        },
+        "required": false,
+        "type": {
+          "name": "Reference",
+          "referenceTypeId": "channel"
+        },
+        "inputHint": "SingleLine"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Customer custom type used by the iOS app to:
- Store the APNs token used for delivering reservation notifications;
- Store the reference for the 'my store' (used along with omni channel feature)

cc @cneijenhuis 