### PR TITLE
Remove empty states from zones

### DIFF
--- a/data/zones.json
+++ b/data/zones.json
@@ -2,8 +2,8 @@
     "name": "Europe",
     "description": "",
     "locations": [
-        { "country": "AT", "state": "" },
-        { "country": "DE", "state": "" },
-        { "country": "NL", "state": "" }
+        { "country": "AT" },
+        { "country": "DE" },
+        { "country": "NL" }
     ]
 }


### PR DESCRIPTION
These empty states are preventing the platform from using the shipping methods for this zone on products.

It makes all shipping methods unusable and doesn't allow to finish checkout.