### PR TITLE
fix, exit if the client is invalid

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -50,6 +50,11 @@ export const createRetry = (retries = RETRIES) => {
       .catch(error => {
         // debugger
         tries++
+
+        if (error.body && error.body.statusCode == 401) {
+          throw error
+        }
+
         if (tries > retries) {
           throw error
         }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -51,7 +51,7 @@ export const createRetry = (retries = RETRIES) => {
         // debugger
         tries++
 
-        if (error.body && error.body.statusCode == 401) {
+        if (error.body && error.body.statusCode === 401) {
           throw error
         }
 


### PR DESCRIPTION
if the client is invalid, there is no error is thrown.

So this PR check if the client is invalid then it throw error without `retry` which causing the script to exit and log it into `import-error.log`